### PR TITLE
Feat: Version strings can now be modified and merged into a complex multiline files.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Template used for updating metadata file'
     required: true
     default: 'version := "%d.%d.%d"'
+  generic_merge_version_file:
+    description: "Don't overwrite the entire version file, but merge using the template pattern"
+    required: false
+    default: false
 outputs:
   version: # id of output
     description: 'Version that was written to files'
@@ -23,6 +27,7 @@ runs:
     PACKAGR_VERSION_BUMP_TYPE: ${{ inputs.version_bump_type }}
     PACKAGR_VERSION_METADATA_PATH: ${{ inputs.version_metadata_path }}
     PACKAGR_GENERIC_VERSION_TEMPLATE: ${{ inputs.generic_version_template }}
+    PACKAGR_GENERIC_MERGE_VERSION_FILE: :${{ inputs.generic_merge_version_file }}
 branding:
   icon: 'chevrons-up'
   color: 'green'


### PR DESCRIPTION
Instead of matching the whole file with the template, you can now only match a single line and merge the new version into the previous file without overwriting the entire version file.

For a an example checkout the test data:
https://github.com/zshel/bumpr/tree/master/pkg/engine/testdata/generic/generic_merge_analogj_test


Requires: https://github.com/PackagrIO/bumpr/pull/8