### PR TITLE
Fix: generic_merge_version_file Input not working

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,10 @@ inputs:
     required: true
     default: 'version := "%d.%d.%d"'
   generic_merge_version_file:
-    description: "Boolean value: Don't overwrite the entire version file, but merge using the template pattern"
+    description: "Don't overwrite the entire version file, but merge using the template pattern"
+    type: boolean
     required: false
-    type: string
-    default: 'false'
+    default: false
 outputs:
   version: # id of output
     description: 'Version that was written to files'

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,10 @@ inputs:
     required: true
     default: 'version := "%d.%d.%d"'
   generic_merge_version_file:
-    description: "Don't overwrite the entire version file, but merge using the template pattern"
-    type: boolean
+    description: "Boolean value: Don't overwrite the entire version file, but merge using the template pattern"
     required: false
-    default: false
+    type: string
+    default: 'false'
 outputs:
   version: # id of output
     description: 'Version that was written to files'

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     PACKAGR_VERSION_BUMP_TYPE: ${{ inputs.version_bump_type }}
     PACKAGR_VERSION_METADATA_PATH: ${{ inputs.version_metadata_path }}
     PACKAGR_GENERIC_VERSION_TEMPLATE: ${{ inputs.generic_version_template }}
-    PACKAGR_GENERIC_MERGE_VERSION_FILE: :${{ inputs.generic_merge_version_file }}
+    PACKAGR_GENERIC_MERGE_VERSION_FILE: ${{ inputs.generic_merge_version_file }}
 branding:
   icon: 'chevrons-up'
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ inputs:
     default: 'version := "%d.%d.%d"'
   generic_merge_version_file:
     description: "Don't overwrite the entire version file, but merge using the template pattern"
+    type: boolean
     required: false
     default: false
 outputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ curl -L -o /srv/packagr/packagr-bumpr $asset_url
 # make bumpr executable
 chmod +x /srv/packagr/packagr-bumpr
 
+printenv
 
 echo "Starting Bumpr $1"
 packagr-bumpr start --scm github --package_type generic

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,6 @@ curl -L -o /srv/packagr/packagr-bumpr $asset_url
 # make bumpr executable
 chmod +x /srv/packagr/packagr-bumpr
 
-printenv
 
 echo "Starting Bumpr $1"
 packagr-bumpr start --scm github --package_type generic


### PR DESCRIPTION
Typo with an added `:` that prevented the action from working when `generic_merge_version_file` was enabled.
Also make it an explicit boolean type so it's more readable.

Make sure this PR is squashed on merge, the history is kinda messy